### PR TITLE
Update vim-minimal in the CentOS 6 image.

### DIFF
--- a/centos/6/Dockerfile
+++ b/centos/6/Dockerfile
@@ -21,7 +21,8 @@ RUN yum -y groupinstall 'Development Tools'
 RUN yum -y install \
     devtoolset-6-toolchain devtoolset-6-binutils-devel \
     cmake cmake28 cmake3 \
-    sudo
+    sudo \
+    vim-minimal
 
 # Enable sudo without tty
 RUN sed -i.bak -n -e '/^Defaults.*requiretty/ { s/^/# /;};/^%wheel.*ALL$/ { s/^/# / ;} ;/^#.*wheel.*NOPASSWD/ { s/^#[ ]*//;};p' /etc/sudoers


### PR DESCRIPTION
The CentOS 6 (x86_64) image is affected by the problem described at
https://bugzilla.redhat.com/show_bug.cgi?id=1329015. Which is apparently
an old notabug present in RedHat/Fedora distributions, manifesting
itself as a conflict on attempt to install a newer vim-common on a
system where an outdated version of vim-minimal is installed.

The common resolution is to update vim-minimal before installing
vim-common. Which is easier to do in the image itself.