### PR TITLE
Disable packpack backports on Debian Stretch.

### DIFF
--- a/debian/stretch/Dockerfile
+++ b/debian/stretch/Dockerfile
@@ -19,7 +19,7 @@ RUN apt-get update && apt-get install -y --force-yes \
     ca-certificates
 #ADD backports.list /etc/apt/sources.list.d/
 #ADD preferences /etc/apt/preferences.d/
-RUN curl -s https://packagecloud.io/install/repositories/packpack/backports/script.deb.sh | bash
+#RUN curl -s https://packagecloud.io/install/repositories/packpack/backports/script.deb.sh | bash
 
 # Install base toolset
 RUN apt-get update && apt-get install -y --force-yes \


### PR DESCRIPTION
Attempt to install packpack backports on Debian Stretch (x86_64)
fails as follows:

```
Installing /etc/apt/sources.list.d/packpack_backports.list...
curl: (22) The requested URL returned error: 404 Not Found

Unable to download repo config from: https://packagecloud.io/install/repositories/packpack/backports/config_file.list?os=debian&dist=9&source=script
```