### PR TITLE
Fix HTTP 404 in Ubuntu Xenial (aarch64) build.

### DIFF
--- a/ubuntu/xenial/Dockerfile
+++ b/ubuntu/xenial/Dockerfile
@@ -10,6 +10,10 @@ ENV DEBIAN_FRONTEND=noninteractive
 # Don't install recommends
 RUN echo 'apt::install-recommends "false";' > /etc/apt/apt.conf.d/00recommends
 
+# Fix HTTP 404 when trying to fetch
+# http://security.ubuntu.com/ubuntu/dists/xenial-security/main/binary-arm64/Packages
+ADD sources.list /etc/apt/sources.list
+
 # Enable extra repositories
 RUN apt-get update && apt-get install -y --force-yes \
     apt-transport-https \

--- a/ubuntu/xenial/sources.list
+++ b/ubuntu/xenial/sources.list
@@ -1,0 +1,49 @@
+# See http://help.ubuntu.com/community/UpgradeNotes for how to upgrade to
+# newer versions of the distribution.
+deb http://ports.ubuntu.com/ubuntu-ports/ xenial main restricted
+# deb-src http://ports.ubuntu.com/ubuntu-ports/ xenial main restricted
+
+## Major bug fix updates produced after the final release of the
+## distribution.
+deb http://ports.ubuntu.com/ubuntu-ports/ xenial-updates main restricted
+# deb-src http://ports.ubuntu.com/ubuntu-ports/ xenial-updates main restricted
+
+## N.B. software from this repository is ENTIRELY UNSUPPORTED by the Ubuntu
+## team. Also, please note that software in universe WILL NOT receive any
+## review or updates from the Ubuntu security team.
+deb http://ports.ubuntu.com/ubuntu-ports/ xenial universe
+deb-src http://ports.ubuntu.com/ubuntu-ports/ xenial universe
+deb http://ports.ubuntu.com/ubuntu-ports/ xenial-updates universe
+deb-src http://ports.ubuntu.com/ubuntu-ports/ xenial-updates universe
+
+## N.B. software from this repository is ENTIRELY UNSUPPORTED by the Ubuntu
+## team, and may not be under a free licence. Please satisfy yourself as to
+## your rights to use the software. Also, please note that software in
+## multiverse WILL NOT receive any review or updates from the Ubuntu
+## security team.
+deb http://ports.ubuntu.com/ubuntu-ports/ xenial multiverse
+# deb-src http://ports.ubuntu.com/ubuntu-ports/ xenial multiverse
+deb http://ports.ubuntu.com/ubuntu-ports/ xenial-updates multiverse
+# deb-src http://ports.ubuntu.com/ubuntu-ports/ xenial-updates multiverse
+
+## N.B. software from this repository may not have been tested as
+## extensively as that contained in the main release, although it includes
+## newer versions of some applications which may provide useful features.
+## Also, please note that software in backports WILL NOT receive any review
+## or updates from the Ubuntu security team.
+deb http://ports.ubuntu.com/ubuntu-ports/ xenial-backports main restricted universe multiverse
+# deb-src http://ports.ubuntu.com/ubuntu-ports/ xenial-backports main restricted universe multiverse
+
+## Uncomment the following two lines to add software from Canonical's
+## 'partner' repository.
+## This software is not part of Ubuntu, but is offered by Canonical and the
+## respective vendors as a service to Ubuntu users.
+# deb http://archive.canonical.com/ubuntu xenial partner
+# deb-src http://archive.canonical.com/ubuntu xenial partner
+
+deb http://ports.ubuntu.com/ubuntu-ports xenial-security main restricted
+# deb-src http://ports.ubuntu.com/ubuntu-ports xenial-security main restricted
+deb http://ports.ubuntu.com/ubuntu-ports xenial-security universe
+deb-src http://ports.ubuntu.com/ubuntu-ports xenial-security universe
+deb http://ports.ubuntu.com/ubuntu-ports xenial-security multiverse
+# deb-src http://ports.ubuntu.com/ubuntu-ports xenial-security multiverse


### PR DESCRIPTION
The problem was in invalid URLs for xenial-security in
/etc/apt/sources.list.