### PR TITLE
Update vim-minimal in Fedora 24/25 images to avoid conflicts with vim-common.

### DIFF
--- a/fedora/24/Dockerfile
+++ b/fedora/24/Dockerfile
@@ -18,6 +18,7 @@ RUN dnf -y group install 'C Development Tools and Libraries'
 RUN dnf -y group install 'RPM Development Tools'
 RUN dnf -y install fedora-packager
 RUN dnf -y install sudo git ccache cmake
+RUN dnf -y update vim-minimal
 
 # Enable cache system-wide
 ENV PATH /usr/lib/ccache:/usr/local/bin:/usr/local/sbin:/usr/bin:/usr/sbin:/bin:/sbin

--- a/fedora/25/Dockerfile
+++ b/fedora/25/Dockerfile
@@ -18,6 +18,7 @@ RUN dnf -y group install 'C Development Tools and Libraries'
 RUN dnf -y group install 'RPM Development Tools'
 RUN dnf -y install fedora-packager
 RUN dnf -y install sudo git ccache cmake
+RUN dnf -y update vim-minimal
 
 # Enable cache system-wide
 ENV PATH /usr/lib/ccache:/usr/local/bin:/usr/local/sbin:/usr/bin:/usr/sbin:/bin:/sbin


### PR DESCRIPTION
The problem described in https://github.com/packpack/packpack-docker-images/pull/2 applies to Fedora 24/25 as well. Which wasn't discovered previously due to a problem with my .travis.yml.

```
$ docker pull aarch64/fedora:24
24: Pulling from aarch64/fedora
Digest: sha256:abb79831ef4e60a183692ee8e086f358d6c93872a75e0607d92c52065a51c082
Status: Image is up to date for aarch64/fedora:24
$ docker run -it aarch64/fedora:24 /bin/bash
[root@2ffca7d8508e /]# dnf -y install vim-common
Fedora 24 - aarch64 - Updates                                                                                                                  1.2 MB/s |  16 MB     00:13
Fedora 24 - aarch64                                                                                                                            6.5 MB/s |  41 MB     00:06
Last metadata expiration check: 0:00:53 ago on Wed Apr 12 17:45:59 2017.
Dependencies resolved.
===============================================================================================================================================================================
 Package                                      Arch                                  Version                                        Repository                             Size
===============================================================================================================================================================================
Installing:
 vim-common                                   aarch64                               2:8.0.425-1.fc24                               updates                               6.6 M
 vim-filesystem                               aarch64                               2:8.0.425-1.fc24                               updates                                33 k

Transaction Summary
===============================================================================================================================================================================
Install  2 Packages

Total download size: 6.6 M
Installed size: 28 M
Downloading Packages:
1/2): vim-filesystem-8.0.425-1.fc24.aarch64.rpm                                                                                                17 kB/s |  33 kB     00:01
(2/2): vim-common-8.0.425-1.fc24.aarch64.rpm                                                                                                   1.3 MB/s | 6.6 MB     00:05
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
Total                                                                                                                                          1.2 MB/s | 6.6 MB     00:05
Running transaction check
Transaction check succeeded.
Running transaction test
The downloaded packages were saved in cache until the next successful transaction.
You can remove cached packages by executing 'dnf clean packages'.
Error: Transaction check error:
  file /usr/share/man/man1/vim.1.gz from install of vim-common-2:8.0.425-1.fc24.aarch64 conflicts with file from package vim-minimal-2:7.4.1718-1.fc24.aarch64
```