### PR TITLE
Update vim-minimal in Fedora 24/25 images to avoid conflicts with vim-common.

### DIFF
--- a/fedora/24/Dockerfile
+++ b/fedora/24/Dockerfile
@@ -18,6 +18,7 @@ RUN dnf -y group install 'C Development Tools and Libraries'
 RUN dnf -y group install 'RPM Development Tools'
 RUN dnf -y install fedora-packager
 RUN dnf -y install sudo git ccache cmake
+RUN dnf -y update vim-minimal
 
 # Enable cache system-wide
 ENV PATH /usr/lib/ccache:/usr/local/bin:/usr/local/sbin:/usr/bin:/usr/sbin:/bin:/sbin

--- a/fedora/25/Dockerfile
+++ b/fedora/25/Dockerfile
@@ -18,6 +18,7 @@ RUN dnf -y group install 'C Development Tools and Libraries'
 RUN dnf -y group install 'RPM Development Tools'
 RUN dnf -y install fedora-packager
 RUN dnf -y install sudo git ccache cmake
+RUN dnf -y update vim-minimal
 
 # Enable cache system-wide
 ENV PATH /usr/lib/ccache:/usr/local/bin:/usr/local/sbin:/usr/bin:/usr/sbin:/bin:/sbin


### PR DESCRIPTION
The problem described in #2 applies to Fedora 24/25 as well. Which wasn't discovered previously due to a problem with my .travis.yml.

```
$ docker pull fedora:24
24: Pulling from library/fedora
Digest: sha256:7ffee69dbfaea363cba55db07942a5c0d29f291eaf510edd6c07f139001f4174
Status: Image is up to date for fedora:24
$ docker run -it fedora:24 /bin/bash
[root@e4ad3359ab9b /]# dnf -y install vim-common
Fedora 24 - x86_64 - Updates                                                                                                 486 kB/s |  22 MB     00:46
Fedora 24 - x86_64                                                                                                           474 kB/s |  47 MB     01:41
Last metadata expiration check: 0:01:20 ago on Wed Apr 12 17:52:25 2017.
Dependencies resolved.
=============================================================================================================================================================
 Package                                 Arch                            Version                                      Repository                        Size
=============================================================================================================================================================
Installing:
 vim-common                              x86_64                          2:8.0.514-1.fc24                             updates                          6.6 M
 vim-filesystem                          x86_64                          2:8.0.514-1.fc24                             updates                           33 k

Transaction Summary
=============================================================================================================================================================
Install  2 Packages

Total download size: 6.6 M
Installed size: 28 M
Downloading Packages:
(1/2): vim-filesystem-8.0.514-1.fc24.x86_64.rpm                                                                              259 kB/s |  33 kB     00:00
(2/2): vim-common-8.0.514-1.fc24.x86_64.rpm                                                                                  201 kB/s | 6.6 MB     00:33
-------------------------------------------------------------------------------------------------------------------------------------------------------------
Total                                                                                                                        196 kB/s | 6.6 MB     00:34
Running transaction check
Transaction check succeeded.
Running transaction test
The downloaded packages were saved in cache until the next successful transaction.
You can remove cached packages by executing 'dnf clean packages'.
Error: Transaction check error:
  file /usr/share/man/man1/vim.1.gz from install of vim-common-2:8.0.514-1.fc24.x86_64 conflicts with file from package vim-minimal-2:7.4.1718-1.fc24.x86_64
```