### PR TITLE
Disable packpack backports to fix Fedora 25 x86_64 image build.

### DIFF
--- a/fedora/25/Dockerfile
+++ b/fedora/25/Dockerfile
@@ -10,7 +10,7 @@ RUN yum -y install \
     curl \
     pygpgme \
     yum-utils
-RUN curl -s https://packagecloud.io/install/repositories/packpack/backports/script.rpm.sh | bash
+# RUN curl -s https://packagecloud.io/install/repositories/packpack/backports/script.rpm.sh | bash
 
 # Install base toolset
 RUN dnf -y group install 'Development Tools'


### PR DESCRIPTION
Fedora 25 x86_64 build fails with the following obscure error (tried it on 2 different machines):

```
$ make fedora-25

Step 8 : RUN dnf -y group install 'RPM Development Tools'
 ---> Running in ed7a397dc488
Last metadata expiration check: 0:02:34 ago on Wed Apr 12 18:39:57 2017.
Dependencies resolved.
================================================================================
 Group                          Packages
================================================================================
Marking packages as installed by the group:
 @RPM Development Tools         koji       rpm-build         redhat-rpm-config
                                mock       rpmdevtools
================================================================================
 Package                       Arch       Version             Repository   Size
================================================================================
Installing:
 btrfs-progs                   x86_64     4.6.1-1.fc25        fedora      640 k
 bzip2                         x86_64     1.0.6-21.fc25       updates      57 k
 createrepo_c                  x86_64     0.10.0-6.fc25       fedora       68 k
 createrepo_c-libs             x86_64     0.10.0-6.fc25       fedora       94 k
 distribution-gpg-keys         noarch     1.11-1.fc25         updates     134 k
 drpm                          x86_64     0.3.0-3.fc25        fedora       67 k
 dwz                           x86_64     0.12-2.fc24         fedora      107 k
 fakeroot                      x86_64     1.20.2-4.fc24       fedora      101 k
 fakeroot-libs                 x86_64     1.20.2-4.fc24       fedora       35 k
 file                          x86_64     5.29-4.fc25         updates      68 k
 fpc-srpm-macros               noarch     1.0-1.fc25          fedora      7.6 k
 ghc-srpm-macros               noarch     1.4.2-4.fc25        fedora      8.6 k
 gnat-srpm-macros              noarch     4-1.fc25            fedora      9.0 k
 go-srpm-macros                noarch     2-7.fc25            fedora      8.6 k
 koji                          noarch     1.11.0-1.fc25       updates     293 k
 libuser                       x86_64     0.62-4.fc25         fedora      397 k
 mock                          noarch     1.3.4-1.fc25        updates     187 k
 ocaml-srpm-macros             noarch     2-4.fc24            fedora      8.0 k
 passwd                        x86_64     0.79-8.fc24         fedora      109 k
 perl-srpm-macros              noarch     1-20.fc25           fedora       10 k
 pigz                          x86_64     2.3.4-1.fc25        updates      85 k
 procps-ng                     x86_64     3.3.10-11.fc24      fedora      389 k
 pyOpenSSL                     noarch     16.0.0-2.fc25       fedora       86 k
 python-enum34                 noarch     1.0.4-6.fc25        fedora       57 k
 python-ipaddress              noarch     1.0.16-3.fc25       fedora       39 k
 python-krbV                   x86_64     1.0.90-12.fc25      fedora       58 k
 python-pycparser              noarch     2.14-7.fc25         fedora      109 k
 python-srpm-macros            noarch     3-12.fc25           updates     8.5 k
 python2-cffi                  x86_64     1.7.0-2.fc25        fedora      221 k
 python2-cryptography          x86_64     1.5.3-3.fc25        updates     482 k
 python2-dateutil              noarch     1:2.6.0-1.fc25      updates     248 k
 python2-idna                  noarch     2.5-1.fc25          updates      98 k
 python2-kerberos              x86_64     1.2.5-1.fc25        fedora       32 k
 python2-libcomps              x86_64     0.1.7-5.fc25        fedora       47 k
 python2-ply                   noarch     3.8-2.fc25          fedora      107 k
 python2-pyasn1                noarch     0.2.3-1.fc25        updates     106 k
 python2-pysocks               noarch     1.5.6-5.fc25        fedora       25 k
 python2-requests              noarch     2.10.0-4.fc25       fedora      107 k
 python2-requests-kerberos     noarch     0.10.0-2.fc25       fedora       25 k
 python2-urllib3               noarch     1.15.1-3.fc25       fedora      128 k
 python3-chardet               noarch     2.3.0-1.fc25        fedora      244 k
 python3-distro                noarch     1.0.3-1.fc25        updates      31 k
 python3-pysocks               noarch     1.5.6-5.fc25        fedora       25 k
 python3-requests              noarch     2.10.0-4.fc25       fedora      110 k
 python3-urllib3               noarch     1.15.1-3.fc25       fedora      136 k
 qt5-srpm-macros               noarch     5.7.1-1.fc25        updates     7.9 k
 redhat-rpm-config             noarch     45-1.fc25           updates      60 k
 rpm-build                     x86_64     4.13.0.1-1.fc25     updates     147 k
 rpmdevtools                   noarch     8.9-1.fc25          fedora      105 k
 systemd-container             x86_64     231-14.fc25         updates     412 k
 usermode                      x86_64     1.111-8.fc24        fedora      197 k
 xz                            x86_64     5.2.2-2.fc24        fedora      148 k
Upgrading:
 file-libs                     x86_64     5.29-4.fc25         updates     496 k

Transaction Summary
================================================================================
Install  52 Packages
Upgrade   1 Package

Total download size: 6.8 M
Downloading Packages:
/usr/share/doc/file-libs/ChangeLog: No such file or directory
cannot reconstruct rpm from disk files
The downloaded packages were saved in cache until the next successful transaction.
You can remove cached packages by executing 'dnf clean packages'.
Traceback (most recent call last):
  File "/usr/bin/dnf", line 58, in <module>
    main.user_main(sys.argv[1:], exit_code=True)
  File "/usr/lib/python3.5/site-packages/dnf/cli/main.py", line 174, in user_main
    errcode = main(args)
  File "/usr/lib/python3.5/site-packages/dnf/cli/main.py", line 60, in main
    return _main(base, args)
  File "/usr/lib/python3.5/site-packages/dnf/cli/main.py", line 120, in _main
    ret = resolving(cli, base)
  File "/usr/lib/python3.5/site-packages/dnf/cli/main.py", line 149, in resolving
    base.do_transaction(display=displays)
  File "/usr/lib/python3.5/site-packages/dnf/cli/cli.py", line 212, in do_transaction
    total_cb)
  File "/usr/lib/python3.5/site-packages/dnf/base.py", line 877, in download_packages
    errors = dnf.repo.download_payloads(payloads, drpm)
  File "/usr/lib/python3.5/site-packages/dnf/repo.py", line 149, in download_payloads
    drpm.wait()
  File "/usr/lib/python3.5/site-packages/dnf/drpm.py", line 169, in wait
    self.job_done(pid, code)
  File "/usr/lib/python3.5/site-packages/dnf/drpm.py", line 131, in job_done
    pload = self.jobs.pop(pid)
KeyError: 8
The command '/bin/sh -c dnf -y group install 'RPM Development Tools'' returned a non-zero code: 1
Makefile:26: recipe for target 'fedora-25' failed
make: *** [fedora-25] Error 1
```

I have no idea what that error means and how to solve it properly. Tried a number of workarounds, and disabling packpack backports was the only thing that worked.