### PR TITLE
add fedora 26 docker file

### DIFF
--- a/fedora/26/Dockerfile
+++ b/fedora/26/Dockerfile
@@ -1,0 +1,27 @@
+FROM fedora:26
+MAINTAINER Roman Tsisyk <roman@tarantool.org>
+
+# Fix missing locales
+ENV LC_ALL="C.UTF-8" LANG="C.UTF-8"
+
+# Enable extra repositories
+RUN yum -y install \
+    wget \
+    curl \
+    pygpgme \
+    yum-utils
+# RUN curl -s https://packagecloud.io/install/repositories/packpack/backports/script.rpm.sh | bash
+
+# Install base toolset
+RUN dnf -y group install 'Development Tools'
+RUN dnf -y group install 'C Development Tools and Libraries'
+RUN dnf -y group install 'RPM Development Tools'
+RUN dnf -y install fedora-packager
+RUN dnf -y install sudo git ccache cmake
+RUN dnf -y update vim-minimal
+
+# Enable cache system-wide
+ENV PATH /usr/lib/ccache:/usr/local/bin:/usr/local/sbin:/usr/bin:/usr/sbin:/bin:/sbin
+
+# Enable sudo without tty
+RUN sed -i.bak -n -e '/^Defaults.*requiretty/ { s/^/# /;};/^%wheel.*ALL$/ { s/^/# / ;} ;/^#.*wheel.*NOPASSWD/ { s/^#[ ]*//;};p' /etc/sudoers


### PR DESCRIPTION
Add docker file to support fedora 26.

I've pushed the resulting image to my own repo, but it would be nice if this were pushed to the main packpack repo. Thanks!

https://hub.docker.com/r/knnniggett/packpack/
