### PR TITLE
Replace deprecated 'aarch64' in Dockerfiles with 'arm64v8'.

### DIFF
--- a/debian/jessie/Dockerfile
+++ b/debian/jessie/Dockerfile
@@ -1,4 +1,4 @@
-FROM aarch64/debian:jessie
+FROM arm64v8/debian:jessie
 MAINTAINER Roman Tsisyk <roman@tarantool.org>
 
 # Fix missing locales

--- a/debian/sid/Dockerfile
+++ b/debian/sid/Dockerfile
@@ -1,4 +1,4 @@
-FROM aarch64/debian:sid
+FROM arm64v8/debian:sid
 MAINTAINER Roman Tsisyk <roman@tarantool.org>
 
 # Fix missing locales

--- a/debian/stretch/Dockerfile
+++ b/debian/stretch/Dockerfile
@@ -1,4 +1,4 @@
-FROM aarch64/debian:stretch
+FROM arm64v8/debian:stretch
 MAINTAINER Roman Tsisyk <roman@tarantool.org>
 
 # Fix missing locales

--- a/fedora/24/Dockerfile
+++ b/fedora/24/Dockerfile
@@ -1,4 +1,4 @@
-FROM aarch64/fedora:24
+FROM arm64v8/fedora:24
 MAINTAINER Alexey Kopytov <akopytov@gmail.com>
 
 # Fix missing locales

--- a/fedora/25/Dockerfile
+++ b/fedora/25/Dockerfile
@@ -1,4 +1,4 @@
-FROM aarch64/fedora:25
+FROM arm64v8/fedora:25
 MAINTAINER Alexey Kopytov <akopytov@gmail.com>
 
 # Fix missing locales

--- a/ubuntu/trusty/Dockerfile
+++ b/ubuntu/trusty/Dockerfile
@@ -1,4 +1,4 @@
-FROM aarch64/ubuntu:trusty
+FROM arm64v8/ubuntu:trusty
 MAINTAINER Roman Tsisyk <roman@tarantool.org>
 
 # Fix missing locales

--- a/ubuntu/xenial/Dockerfile
+++ b/ubuntu/xenial/Dockerfile
@@ -1,4 +1,4 @@
-FROM aarch64/ubuntu:xenial
+FROM arm64v8/ubuntu:xenial
 MAINTAINER Roman Tsisyk <roman@tarantool.org>
 
 # Fix missing locales

--- a/ubuntu/yakkety/Dockerfile
+++ b/ubuntu/yakkety/Dockerfile
@@ -1,4 +1,4 @@
-FROM aarch64/ubuntu:yakkety
+FROM arm64v8/ubuntu:yakkety
 MAINTAINER Roman Tsisyk <roman@tarantool.org>
 
 # Fix missing locales

--- a/ubuntu/zesty/Dockerfile
+++ b/ubuntu/zesty/Dockerfile
@@ -1,4 +1,4 @@
-FROM aarch64/ubuntu:zesty
+FROM arm64v8/ubuntu:zesty
 MAINTAINER Roman Tsisyk <roman@tarantool.org>
 
 # Fix missing locales


### PR DESCRIPTION
The 'aarch64' organization is deprecated in favor the more specific
'arm64v8' organization, as per
https://github.com/docker-library/official-images#architectures-other-than-amd64

CentOS has not caught up with the new naming yet, so its Dockerfile
still uses aarch64.