### PR TITLE
Add Dockerfile for Alpine Linux 3.6

### DIFF
--- a/alpine/3.6/Dockerfile
+++ b/alpine/3.6/Dockerfile
@@ -1,0 +1,6 @@
+FROM alpine:3.6
+MAINTAINER Konstantin Nazarov <mail@kn.am>
+
+RUN set -x \
+    && apk add --no-cache su-exec make git tar xz alpine-sdk sudo \
+    && sed -i.bak -n -e '/^Defaults.*requiretty/ { s/^/# /;};/^%wheel.*ALL$/ { s/^/# / ;} ;/^#.*wheel.*NOPASSWD/ { s/^#[ ]*//;};p' /etc/sudoers


### PR DESCRIPTION
This is required to support Alpine in packpack