### PR TITLE
Remove Debian Jessie backports and updates repositories

### DIFF
--- a/debian/jessie/Dockerfile
+++ b/debian/jessie/Dockerfile
@@ -17,7 +17,6 @@ RUN apt-get update && apt-get install -y --force-yes \
     wget \
     gnupg \
     ca-certificates
-ADD backports.list /etc/apt/sources.list.d/
 ADD preferences /etc/apt/preferences.d/
 RUN curl -s https://packagecloud.io/install/repositories/packpack/backports/script.deb.sh | bash
 

--- a/debian/jessie/Dockerfile
+++ b/debian/jessie/Dockerfile
@@ -10,6 +10,9 @@ ENV DEBIAN_FRONTEND=noninteractive
 # Don't install recommends
 RUN echo 'apt::install-recommends "false";' > /etc/apt/apt.conf.d/00recommends
 
+# Drop EOL repositories
+RUN sed -i '/jessie-updates/d' /etc/apt/sources.list
+
 # Enable extra repositories
 RUN apt-get update && apt-get install -y --force-yes \
     apt-transport-https \

--- a/debian/jessie/backports.list
+++ b/debian/jessie/backports.list
@@ -1,2 +1,0 @@
-deb http://ftp.debian.org/debian jessie-backports main
-deb-src http://ftp.debian.org/debian jessie-backports main


### PR DESCRIPTION
They were removed from the official mirror as not a part of the LTS architecture. See [1], [2] ('Deprecation of LTS support for backports'), [3] for more information.

[1]: https://lists.debian.org/debian-devel-announce/2019/03/msg00006.html
[2]: https://backports.debian.org/
[3]: https://github.com/debuerreotype/docker-debian-artifacts/issues/66