### PR TITLE
New CentOS 7.7 released

### DIFF
--- a/centos/7/Dockerfile
+++ b/centos/7/Dockerfile
@@ -1,6 +1,8 @@
 FROM centos:7
 MAINTAINER Roman Tsisyk <roman@tarantool.org>
 
+ARG DEVTOOLSET=devtoolset-8
+
 # Fix missing locales
 ENV LC_ALL="en_US.UTF-8" LANG="en_US.UTF-8"
 
@@ -16,7 +18,7 @@ RUN curl -s https://packagecloud.io/install/repositories/packpack/backports/scri
 # Install base toolset
 RUN yum -y groupinstall 'Development Tools'
 RUN yum -y install \
-    devtoolset-6-toolchain devtoolset-6-binutils-devel \
+    ${DEVTOOLSET}-toolchain ${DEVTOOLSET}-binutils-devel \
     cmake cmake28 cmake3 \
     sudo
 
@@ -24,16 +26,18 @@ RUN yum -y install \
 RUN sed -i.bak -n -e '/^Defaults.*requiretty/ { s/^/# /;};/^%wheel.*ALL$/ { s/^/# / ;} ;/^#.*wheel.*NOPASSWD/ { s/^#[ ]*//;};p' /etc/sudoers
 
 # Enable devtoolset and ccache system-wide
-# See /opt/rh/devtoolset-6/enable
-ENV PATH=/usr/lib64/ccache:/opt/rh/devtoolset-6/root/usr/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
-ENV LD_LIBRARY_PATH=/opt/rh/devtoolset-6/root/usr/lib64:/opt/rh/devtoolset-6/root/usr/lib
-ENV PERL5LIB=/opt/rh/devtoolset-6/root//usr/lib64/perl5/vendor_perl:/opt/rh/devtoolset-6/root/usr/lib/perl5:/opt/rh/devtoolset-6/root//usr/share/perl5/vendor_perl
-ENV PYTHONPATH=/opt/rh/devtoolset-6/root/usr/lib64/python2.7/site-packages:/opt/rh/devtoolset-6/root/usr/lib/python2.7/site-packages
-ENV XDG_CONFIG_DIRS=/opt/rh/devtoolset-6/root/etc/xdg:/etc/xdg
-ENV XDG_DATA_DIRS=/opt/rh/devtoolset-6/root/usr/share:/usr/local/share:/usr/share
+# See /opt/rh/${DEVTOOLSET}/enable
+ENV PATH=/usr/lib64/ccache:/opt/rh/${DEVTOOLSET}/root/usr/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+ENV LD_LIBRARY_PATH=/opt/rh/${DEVTOOLSET}/root/usr/lib64:/opt/rh/${DEVTOOLSET}/root/usr/lib
+ENV PERL5LIB=/opt/rh/${DEVTOOLSET}/root/usr/lib64/perl5/vendor_perl:/opt/rh/${DEVTOOLSET}/root/usr/lib/perl5:/opt/rh/${DEVTOOLSET}/root/usr/share/perl5/vendor_perl
+ENV PYTHONPATH=/opt/rh/${DEVTOOLSET}/root/usr/lib64/python2.7/site-packages:/opt/rh/${DEVTOOLSET}/root/usr/lib/python2.7/site-packages
+ENV XDG_CONFIG_DIRS=/opt/rh/${DEVTOOLSET}/root/etc/xdg:/etc/xdg
+ENV XDG_DATA_DIRS=/opt/rh/${DEVTOOLSET}/root/usr/share:/usr/local/share:/usr/share
+
 # sudo wrapper from devtoolset is buggy, remove it
-RUN rm -f /opt/rh/devtoolset-6/root/usr/bin/sudo
+RUN rm -f /opt/rh/${DEVTOOLSET}/root/usr/bin/sudo
 
 # A workaround for [Errno 14] HTTP Error 404 - Not Found
 # https://bugs.centos.org/view.php?id=12793
-RUN rm -rf /etc/yum.repos.d/CentOS-SCLo-scl-rh.repo
+RUN sed -e '/\[centos-sclo-sclo-source\]/,+6d' -i /etc/yum.repos.d/CentOS-SCLo-scl.repo
+RUN sed -e '/\[centos-sclo-rh-source\]/,+6d' -i /etc/yum.repos.d/CentOS-SCLo-scl-rh.repo


### PR DESCRIPTION
On 15.09.2019 released the new CentOS 7.7 in which repositories
devtoolset-6* packages were removed. Also repodata files were removed
at CentOS-SCLo-scl and CentOS-SCLo-scl-hp sources repositories.
To fix these issues the new devtoolset-8* packages were set instead
of devtoolset-6* and CentOS-SCLo-scl and CentOS-SCLo-scl-hp sources
repositories were removed from YUM configuration.