### PR TITLE
Debian Wheezy moving to archive.debian.org repo (i386)

### DIFF
--- a/debian/wheezy/Dockerfile
+++ b/debian/wheezy/Dockerfile
@@ -10,6 +10,10 @@ ENV DEBIAN_FRONTEND=noninteractive
 # Don't install recommends
 RUN echo 'apt::install-recommends "false";' > /etc/apt/apt.conf.d/00recommends
 
+# Use the archive repository
+ADD sources.list /etc/apt/
+RUN echo "Acquire::Check-Valid-Until false;" > /etc/apt/apt.conf.d/00nocheckvalid
+
 # Enable extra repositories
 RUN apt-get update && apt-get install -y --force-yes \
     apt-transport-https \

--- a/debian/wheezy/backports.list
+++ b/debian/wheezy/backports.list
@@ -1,2 +1,2 @@
-deb http://ftp.debian.org/debian wheezy-backports main
-deb-src http://ftp.debian.org/debian wheezy-backports main
+deb http://archive.debian.org/debian wheezy-backports main
+deb-src http://archive.debian.org/debian wheezy-backports main

--- a/debian/wheezy/sources.list
+++ b/debian/wheezy/sources.list
@@ -1,0 +1,2 @@
+deb http://archive.debian.org/debian wheezy main
+deb http://archive.debian.org/debian-security wheezy/updates main


### PR DESCRIPTION
Change Debian Wheezy main, update, and backports repositories to the equivalent repository on archive.debian.org

Related to #40 packpack/packpack#112