### PR TITLE
Update Fedora Rawhide Dockerfile

### DIFF
--- a/fedora/rawhide/Dockerfile
+++ b/fedora/rawhide/Dockerfile
@@ -4,24 +4,19 @@ MAINTAINER Roman Tsisyk <roman@tarantool.org>
 # Fix missing locales
 ENV LC_ALL="C.UTF-8" LANG="C.UTF-8"
 
-# Upgrade Python3, so this does not happen:
-# https://bugzilla.redhat.com/show_bug.cgi?id=1435135
-RUN dnf -y upgrade python3
-
-# Enable extra repositories
-RUN dnf -y install \
-    wget \
-    curl \
-    pygpgme \
-    yum-utils
-#RUN curl -s https://packagecloud.io/install/repositories/packpack/backports/script.rpm.sh | bash
-
 # Install base toolset
 RUN dnf -y group install 'Development Tools'
 RUN dnf -y group install 'C Development Tools and Libraries'
 RUN dnf -y group install 'RPM Development Tools'
 RUN dnf -y install fedora-packager
 RUN dnf -y install sudo git ccache cmake
+
+# The script from packagecloud.io detects the OS as fedora/32 and
+# reports that it does not support this operating system.
+# Commented this out so.
+#
+# Setup backport repository for python2 packages
+# RUN curl -s https://packagecloud.io/install/repositories/packpack/backports/script.rpm.sh | bash
 
 # Enable cache system-wide
 ENV PATH /usr/lib/ccache:/usr/local/bin:/usr/local/sbin:/usr/bin:/usr/sbin:/bin:/sbin


### PR DESCRIPTION
Now it is more or less same as Fedora 31 Dockerfile.

This commit allows to successfully build the image. Before it fails,
because there is no more pygpgme package in Fedora Rawhide repositories.

Commented backports repository enabling, because the packagecloud.io
script detects the operating system as fedora/32 and reports that does
not support it.

The problem with Python 3 was resolved a long time ago, so the
workaround for it is not needed anymore.