### PR TITLE
Add Fedora 32 (x86_64)

### DIFF
--- a/fedora/32/Dockerfile
+++ b/fedora/32/Dockerfile
@@ -1,0 +1,21 @@
+FROM fedora:32
+MAINTAINER Alexander V. Tikhonov <avtikhon@tarantool.org>
+
+# Fix missing locales
+ENV LC_ALL="C.UTF-8" LANG="C.UTF-8"
+
+# Install base toolset
+RUN dnf -y group install 'Development Tools'
+RUN dnf -y group install 'C Development Tools and Libraries'
+RUN dnf -y group install 'RPM Development Tools'
+RUN dnf -y install fedora-packager
+RUN dnf -y install sudo git ccache cmake
+
+# Setup backport repository for python2 packages
+RUN curl -s https://packagecloud.io/install/repositories/packpack/backports/script.rpm.sh | bash
+
+# Enable cache system-wide
+ENV PATH /usr/lib/ccache:/usr/local/bin:/usr/local/sbin:/usr/bin:/usr/sbin:/bin:/sbin
+
+# Enable sudo without tty
+RUN sed -i.bak -n -e '/^Defaults.*requiretty/ { s/^/# /;};/^%wheel.*ALL$/ { s/^/# / ;} ;/^#.*wheel.*NOPASSWD/ { s/^#[ ]*//;};p' /etc/sudoers


### PR DESCRIPTION
Created the new Dockerfile to build Fedora 32,
based on Fedora 31 image.