### PR TITLE
CentOS 7: remove dead base-source repository

### DIFF
--- a/centos/7/Dockerfile
+++ b/centos/7/Dockerfile
@@ -62,3 +62,6 @@ RUN sed -e '/\[extras-source\]/,+6d' -i /etc/yum.repos.d/CentOS-Sources.repo
 
 # The same as above, but for the updates-source repository.
 RUN sed -e '/\[updates-source\]/,+6d' -i /etc/yum.repos.d/CentOS-Sources.repo
+
+# The same as above, but for the base-source repository.
+RUN sed -e '/\[base-source\]/,+6d' -i /etc/yum.repos.d/CentOS-Sources.repo


### PR DESCRIPTION
The similar to the following past commits:

* 9d317effb271665cd99dbaa264b30bc9fa432617 ('CentOS 7: remove dead
  extras-source repository')
* ac66a9719d5003eb7b2a85576eeb346f4149033c ('CentOS 7: remove dead
  updates-source repository')