### PR TITLE
opensuse: setup yandex mirror respositories

### DIFF
--- a/opensuse/leap/15.0/Dockerfile
+++ b/opensuse/leap/15.0/Dockerfile
@@ -1,6 +1,11 @@
 FROM opensuse/leap:15.0
 MAINTAINER Alexander V. Tikhonov <avtikhon@gmail.com>
 
+# Add the same repositories based on Yandex paths as default
+RUN for f in /etc/zypp/repos.d/* ; do \
+        sed "s#^\(baseurl=http://download.opensuse.org/\)\(.*\)#\1\2\nhttps://mirror.yandex.ru/opensuse/\2#g" -i $f ; \
+    done
+
 # Install base toolset
 RUN zypper install -y \
     autoconf \

--- a/opensuse/leap/15.1/Dockerfile
+++ b/opensuse/leap/15.1/Dockerfile
@@ -1,6 +1,11 @@
 FROM opensuse/leap:15.1
 MAINTAINER Alexander V. Tikhonov <avtikhon@gmail.com>
 
+# Add the same repositories based on Yandex paths as default
+RUN for f in /etc/zypp/repos.d/* ; do \
+        sed "s#^\(baseurl=http://download.opensuse.org/\)\(.*\)#\1\2\nhttps://mirror.yandex.ru/opensuse/\2#g" -i $f ; \
+    done
+
 # Install base toolset
 RUN zypper install -y \
     autoconf \

--- a/opensuse/leap/15.2/Dockerfile
+++ b/opensuse/leap/15.2/Dockerfile
@@ -1,6 +1,11 @@
 FROM opensuse/leap:15.2
 MAINTAINER Alexander V. Tikhonov <avtikhon@gmail.com>
 
+# Add the same repositories based on Yandex paths as default
+RUN for f in /etc/zypp/repos.d/* ; do \
+        sed "s#^\(baseurl=http://download.opensuse.org/\)\(.*\)#\1\2\nhttps://mirror.yandex.ru/opensuse/\2#g" -i $f ; \
+    done
+
 # Install base toolset
 RUN zypper install -y \
     autoconf \


### PR DESCRIPTION
Found that opensuse external repositories can be unreachable. To give
the image ability to find the other opensuse mirrors added setup of
yandex repositories.