### PR TITLE
Set CentOS 6 repositories to Vault archives

### DIFF
--- a/centos/6/CentOS-Base.repo
+++ b/centos/6/CentOS-Base.repo
@@ -1,0 +1,38 @@
+# CentOS-Base.repo
+#
+
+[base]
+name=CentOS-$releasever - Base
+baseurl=http://vault.centos.org/centos/$releasever/os/$basearch/
+gpgcheck=1
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-6
+
+#released updates
+[updates]
+name=CentOS-$releasever - Updates
+baseurl=http://vault.centos.org/centos/$releasever/updates/$basearch/
+gpgcheck=1
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-6
+
+#additional packages that may be useful
+[extras]
+name=CentOS-$releasever - Extras
+baseurl=http://vault.centos.org/centos/$releasever/extras/$basearch/
+gpgcheck=1
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-6
+
+#additional packages that extend functionality of existing packages
+[centosplus]
+name=CentOS-$releasever - Plus
+baseurl=http://vault.centos.org/centos/$releasever/centosplus/$basearch/
+gpgcheck=1
+enabled=0
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-6
+
+#contrib - packages by Centos Users
+[contrib]
+name=CentOS-$releasever - Contrib
+baseurl=http://vault.centos.org/centos/$releasever/contrib/$basearch/
+gpgcheck=1
+enabled=0
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-6

--- a/centos/6/CentOS-SCLo-scl-rh.repo
+++ b/centos/6/CentOS-SCLo-scl-rh.repo
@@ -5,7 +5,7 @@
 
 [centos-sclo-rh]
 name=CentOS-6 - SCLo rh
-baseurl=http://mirror.centos.org/centos/6/sclo/$basearch/rh/
+baseurl=http://vault.centos.org/centos/6/sclo/$basearch/rh/
 gpgcheck=0
 enabled=1
 # gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-SIG-SCLo

--- a/centos/6/CentOS-SCLo-scl.repo
+++ b/centos/6/CentOS-SCLo-scl.repo
@@ -5,7 +5,7 @@
 
 [centos-sclo-sclo]
 name=CentOS-6 - SCLo sclo
-baseurl=http://mirror.centos.org/centos/6/sclo/$basearch/sclo/
+baseurl=http://vault.centos.org/centos/6/sclo/$basearch/sclo/
 gpgcheck=0
 enabled=1
 # gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-SIG-SCLo

--- a/centos/6/Dockerfile
+++ b/centos/6/Dockerfile
@@ -1,25 +1,45 @@
 FROM centos:6
 MAINTAINER Roman Tsisyk <roman@tarantool.org>
 
+# 'Vault' archives do not provide devtoolset-6 (see [1]), which
+# was used in this image before. So, let's use devtoolset-7.
+#
+# [1]: https://vault.centos.org/centos/6/sclo/x86_64/rh/Packages/d/
+ARG DEVTOOLSET=devtoolset-7
+
+# Replace mirror.centos.org with vault.centos.org. The former
+# has no CentOS 6 repositories anymore.
+ADD CentOS-Base.repo /etc/yum.repos.d/
+RUN yum -y makecache
+
 # Fix missing locales
 ENV LC_ALL="en_US.UTF-8" LANG="en_US.UTF-8"
 
-# Enable extra repositories
+# The base image may contain non-latest packages.
+#
+# It looks worthful to update them at this point. For example,
+# ca-certificates update may be important for HTTPS usage.
+RUN yum -y update
+
+# Install software collections and EPEL repositories.
+ADD CentOS-SCLo-scl.repo /etc/yum.repos.d/
+ADD CentOS-SCLo-scl-rh.repo /etc/yum.repos.d/
+RUN yum -y makecache
+RUN yum -y install epel-release
+
+# Install backports repository.
 RUN yum -y install \
     wget \
     curl \
     pygpgme \
     yum-utils
-RUN yum -y install epel-release
-ADD CentOS-SCLo-scl.repo /etc/yum.repos.d/
-ADD CentOS-SCLo-scl-rh.repo /etc/yum.repos.d/
 RUN curl -s https://packagecloud.io/install/repositories/packpack/backports/script.rpm.sh | bash
 RUN yum makecache && yum clean all
 
 # Install base toolset
 RUN yum -y groupinstall 'Development Tools'
 RUN yum -y install \
-    devtoolset-6-toolchain devtoolset-6-binutils-devel \
+    ${DEVTOOLSET}-toolchain ${DEVTOOLSET}-binutils-devel \
     cmake cmake28 cmake3 \
     sudo \
     vim-minimal
@@ -28,12 +48,12 @@ RUN yum -y install \
 RUN sed -i.bak -n -e '/^Defaults.*requiretty/ { s/^/# /;};/^%wheel.*ALL$/ { s/^/# / ;} ;/^#.*wheel.*NOPASSWD/ { s/^#[ ]*//;};p' /etc/sudoers
 
 # Enable devtoolset and ccache system-wide
-# See /opt/rh/devtoolset-6/enable
-ENV PATH=/usr/lib64/ccache:/opt/rh/devtoolset-6/root/usr/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
-ENV LD_LIBRARY_PATH=/opt/rh/devtoolset-6/root/usr/lib64:/opt/rh/devtoolset-6/root/usr/lib
-ENV PERL5LIB=/opt/rh/devtoolset-6/root//usr/lib64/perl5/vendor_perl:/opt/rh/devtoolset-6/root/usr/lib/perl5:/opt/rh/devtoolset-6/root//usr/share/perl5/vendor_perl
-ENV PYTHONPATH=/opt/rh/devtoolset-6/root/usr/lib64/python2.6/site-packages:/opt/rh/devtoolset-6/root/usr/lib/python2.6/site-packages
-ENV XDG_CONFIG_DIRS=/opt/rh/devtoolset-6/root/etc/xdg:/etc/xdg
-ENV XDG_DATA_DIRS=/opt/rh/devtoolset-6/root/usr/share:/usr/local/share:/usr/share
+# See /opt/rh/${DEVTOOLSET}/enable
+ENV PATH=/usr/lib64/ccache:/opt/rh/${DEVTOOLSET}/root/usr/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+ENV LD_LIBRARY_PATH=/opt/rh/${DEVTOOLSET}/root/usr/lib64:/opt/rh/${DEVTOOLSET}/root/usr/lib
+ENV PERL5LIB=/opt/rh/${DEVTOOLSET}/root/usr/lib64/perl5/vendor_perl:/opt/rh/${DEVTOOLSET}/root/usr/lib/perl5:/opt/rh/${DEVTOOLSET}/root/usr/share/perl5/vendor_perl
+ENV PYTHONPATH=/opt/rh/${DEVTOOLSET}/root/usr/lib64/python2.7/site-packages:/opt/rh/${DEVTOOLSET}/root/usr/lib/python2.7/site-packages
+ENV XDG_CONFIG_DIRS=/opt/rh/${DEVTOOLSET}/root/etc/xdg:/etc/xdg
+ENV XDG_DATA_DIRS=/opt/rh/${DEVTOOLSET}/root/usr/share:/usr/local/share:/usr/share
 # sudo wrapper from devtoolset is buggy, remove it
-RUN rm -f /opt/rh/devtoolset-6/root/usr/bin/sudo
+RUN rm -f /opt/rh/${DEVTOOLSET}/root/usr/bin/sudo


### PR DESCRIPTION
    Set CentOS 6 repositories to Vault archives
    
    CentOS 6 end of Life 2020-11 as shown at [1] and its base repository
    file set from local copy with Vault paths:
    
      /etc/yum.repos.d/CentOS-Base.repo
    
    Epel release repositories baseurl changed as suggested at [2] to:
    
      https://download.fedoraproject.org/pub/archive/epel/6/
    
    Also found that devtoolset-6 is not available in Vault archives, so
    devtoolset-7 is needed to be used instead, check [3].
    
    [1] - https://fedoraproject.org/wiki/EPEL#What_packages_and_versions_are_available_in_EPEL.3F
    [2] - https://fedoraproject.org/wiki/EPEL#END_OF_LIFE_RELEASES
    [3] - https://vault.centos.org/centos/6/sclo/x86_64/rh/Packages/d/
