### PR TITLE
Add Dockerfile for packpack builds for Debian 11 (bullseye)

### DIFF
--- a/debian/bullseye/Dockerfile
+++ b/debian/bullseye/Dockerfile
@@ -1,0 +1,38 @@
+FROM debian:bullseye
+MAINTAINER Andrey Kulikov <amdeich@gmail.com>
+
+# Fix missing locales
+ENV LC_ALL="C.UTF-8" LANG="C.UTF-8"
+
+# Skip interactive post-install scripts
+ENV DEBIAN_FRONTEND=noninteractive
+
+# Don't install recommends
+RUN echo 'apt::install-recommends "false";' > /etc/apt/apt.conf.d/00recommends
+
+RUN apt-get update && apt-get install -y \
+    apt-transport-https \
+    curl \
+    wget \
+    gnupg \
+    ca-certificates
+
+# Install base toolset
+RUN apt-get update && apt-get install -y \
+    sudo \
+    git \
+    build-essential \
+    cmake \
+    gdb \
+    ccache \
+    devscripts \
+    debhelper \
+    cdbs \
+    fakeroot \
+    lintian \
+    equivs \
+    rpm \
+    alien
+
+# Enable sudo without password
+RUN echo '%adm ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers


### PR DESCRIPTION
Removed installation of dh-systemd, as this package is not a part of Debian 11 anymore.
It's functionality included into debhelper, which is already used.