### PR TITLE
Add Fedora 33 (x86_64)

### DIFF
--- a/fedora/33/Dockerfile
+++ b/fedora/33/Dockerfile
@@ -1,0 +1,18 @@
+FROM fedora:33
+MAINTAINER Alexander V. Tikhonov <avtikhon@tarantool.org>
+
+# Fix missing locales
+ENV LC_ALL="C.UTF-8" LANG="C.UTF-8"
+
+# Install base toolset
+RUN dnf -y group install 'Development Tools'
+RUN dnf -y group install 'C Development Tools and Libraries'
+RUN dnf -y group install 'RPM Development Tools'
+RUN dnf -y install fedora-packager
+RUN dnf -y install sudo git ccache cmake
+
+# Enable cache system-wide
+ENV PATH /usr/lib/ccache:/usr/local/bin:/usr/local/sbin:/usr/bin:/usr/sbin:/bin:/sbin
+
+# Enable sudo without tty
+RUN sed -i.bak -n -e '/^Defaults.*requiretty/ { s/^/# /;};/^%wheel.*ALL$/ { s/^/# / ;} ;/^#.*wheel.*NOPASSWD/ { s/^#[ ]*//;};p' /etc/sudoers


### PR DESCRIPTION
Created the new Dockerfile to build Fedora 33, based on Fedora 32.
Removed backport part for Python 2 packages due to packages for it
not available and it's not right way to create it manually, better
to use default Python 3 in Fedora 33.

Needed for tarantool/tarantool#5502