### PR TITLE
Setup Python 3 and modules in RPM-based containers

### DIFF
--- a/centos/7/Dockerfile
+++ b/centos/7/Dockerfile
@@ -20,6 +20,8 @@ RUN yum -y groupinstall 'Development Tools'
 RUN yum -y install \
     ${DEVTOOLSET}-toolchain ${DEVTOOLSET}-binutils-devel \
     cmake cmake28 cmake3 \
+    python3 \
+    python3-devel \
     sudo
 
 # Enable sudo without tty

--- a/centos/8/Dockerfile
+++ b/centos/8/Dockerfile
@@ -21,6 +21,8 @@ RUN curl -s https://packagecloud.io/install/repositories/packpack/backports/scri
 RUN yum -y groupinstall 'Development Tools'
 RUN yum -y install \
     cmake \
+    python3 \
+    python3-devel \
     sudo
 
 # Enable sudo without tty

--- a/fedora/29/Dockerfile
+++ b/fedora/29/Dockerfile
@@ -9,7 +9,7 @@ RUN dnf -y group install 'Development Tools'
 RUN dnf -y group install 'C Development Tools and Libraries'
 RUN dnf -y group install 'RPM Development Tools'
 RUN dnf -y install fedora-packager
-RUN dnf -y install sudo git ccache cmake
+RUN dnf -y install sudo git ccache cmake python3
 
 # Enable cache system-wide
 ENV PATH /usr/lib/ccache:/usr/local/bin:/usr/local/sbin:/usr/bin:/usr/sbin:/bin:/sbin

--- a/fedora/30/Dockerfile
+++ b/fedora/30/Dockerfile
@@ -9,7 +9,7 @@ RUN dnf -y group install 'Development Tools'
 RUN dnf -y group install 'C Development Tools and Libraries'
 RUN dnf -y group install 'RPM Development Tools'
 RUN dnf -y install fedora-packager
-RUN dnf -y install sudo git ccache cmake
+RUN dnf -y install sudo git ccache cmake python3
 
 # Enable cache system-wide
 ENV PATH /usr/lib/ccache:/usr/local/bin:/usr/local/sbin:/usr/bin:/usr/sbin:/bin:/sbin

--- a/fedora/31/Dockerfile
+++ b/fedora/31/Dockerfile
@@ -9,7 +9,7 @@ RUN dnf -y group install 'Development Tools'
 RUN dnf -y group install 'C Development Tools and Libraries'
 RUN dnf -y group install 'RPM Development Tools'
 RUN dnf -y install fedora-packager
-RUN dnf -y install sudo git ccache cmake
+RUN dnf -y install sudo git ccache cmake python3
 
 # Setup backport repository for python2 packages
 RUN curl -s https://packagecloud.io/install/repositories/packpack/backports/script.rpm.sh | bash

--- a/fedora/32/Dockerfile
+++ b/fedora/32/Dockerfile
@@ -9,7 +9,7 @@ RUN dnf -y group install 'Development Tools'
 RUN dnf -y group install 'C Development Tools and Libraries'
 RUN dnf -y group install 'RPM Development Tools'
 RUN dnf -y install fedora-packager
-RUN dnf -y install sudo git ccache cmake
+RUN dnf -y install sudo git ccache cmake python3
 
 # Setup backport repository for python2 packages
 RUN curl -s https://packagecloud.io/install/repositories/packpack/backports/script.rpm.sh | bash


### PR DESCRIPTION
Set current Python interpreter version used in containers [1].

1. https://gitlab.com/tarantool/tarantool/-/pipelines/243731352

Part of https://github.com/tarantool/tarantool/issues/5652