### PR TITLE
Update repositories and installed packages to avoid of hanged connections

### DIFF
--- a/centos/7/Dockerfile
+++ b/centos/7/Dockerfile
@@ -6,6 +6,10 @@ ARG DEVTOOLSET=devtoolset-8
 # Fix missing locales
 ENV LC_ALL="en_US.UTF-8" LANG="en_US.UTF-8"
 
+# Update repositories and installed packages to avoid of issues got at:
+#   https://github.com/tarantool/tarantool-qa/issues/60
+RUN yum update -v -y
+
 # Enable extra repositories
 RUN yum -y install \
     wget \
@@ -65,3 +69,6 @@ RUN sed -e '/\[updates-source\]/,+6d' -i /etc/yum.repos.d/CentOS-Sources.repo
 
 # The same as above, but for the base-source repository.
 RUN sed -e '/\[base-source\]/,+6d' -i /etc/yum.repos.d/CentOS-Sources.repo
+
+# Cleanup YUM metadata and decrease image size
+RUN yum clean all

--- a/centos/8/Dockerfile
+++ b/centos/8/Dockerfile
@@ -1,6 +1,10 @@
 FROM centos:8
 MAINTAINER Alexander V. Tikhonov <avtikhon@tarantool.org>
 
+# Update repositories and installed packages to avoid of issues got at:
+#   https://github.com/tarantool/tarantool-qa/issues/60
+RUN dnf update -v -y
+
 # Enable extra tools
 RUN yum -y install wget yum-utils
 
@@ -25,3 +29,6 @@ RUN yum -y install \
 
 # Enable sudo without tty
 RUN sed -i.bak -n -e '/^Defaults.*requiretty/ { s/^/# /;};/^%wheel.*ALL$/ { s/^/# / ;} ;/^#.*wheel.*NOPASSWD/ { s/^#[ ]*//;};p' /etc/sudoers
+
+# Cleanup DNF metadata and decrease image size
+RUN dnf clean all

--- a/fedora/28/Dockerfile
+++ b/fedora/28/Dockerfile
@@ -4,6 +4,10 @@ MAINTAINER Alexey Kopytov <akopytov@gmail.com>
 # Fix missing locales
 ENV LC_ALL="C.UTF-8" LANG="C.UTF-8"
 
+# Update repositories and installed packages to avoid of issues got at:
+#   https://github.com/tarantool/tarantool-qa/issues/60
+RUN dnf update -v -y
+
 # Install base toolset
 RUN dnf -y group install 'Development Tools'
 RUN dnf -y group install 'C Development Tools and Libraries'
@@ -16,3 +20,6 @@ ENV PATH /usr/lib/ccache:/usr/local/bin:/usr/local/sbin:/usr/bin:/usr/sbin:/bin:
 
 # Enable sudo without tty
 RUN sed -i.bak -n -e '/^Defaults.*requiretty/ { s/^/# /;};/^%wheel.*ALL$/ { s/^/# / ;} ;/^#.*wheel.*NOPASSWD/ { s/^#[ ]*//;};p' /etc/sudoers
+
+# Cleanup DNF metadata and decrease image size
+RUN dnf clean all

--- a/fedora/29/Dockerfile
+++ b/fedora/29/Dockerfile
@@ -4,6 +4,12 @@ MAINTAINER Alexey Kopytov <akopytov@gmail.com>
 # Fix missing locales
 ENV LC_ALL="C.UTF-8" LANG="C.UTF-8"
 
+# Update repositories and installed packages to avoid of issues got at:
+#   https://github.com/tarantool/tarantool-qa/issues/60
+RUN echo "Remove disabled 'failovermethod' since Fedora 29"
+RUN sed -i '/^failovermethod=/d' /etc/yum.repos.d/*.repo
+RUN dnf update -v -y
+
 # Install base toolset
 RUN dnf -y group install 'Development Tools'
 RUN dnf -y group install 'C Development Tools and Libraries'
@@ -16,3 +22,6 @@ ENV PATH /usr/lib/ccache:/usr/local/bin:/usr/local/sbin:/usr/bin:/usr/sbin:/bin:
 
 # Enable sudo without tty
 RUN sed -i.bak -n -e '/^Defaults.*requiretty/ { s/^/# /;};/^%wheel.*ALL$/ { s/^/# / ;} ;/^#.*wheel.*NOPASSWD/ { s/^#[ ]*//;};p' /etc/sudoers
+
+# Cleanup DNF metadata and decrease image size
+RUN dnf clean all

--- a/fedora/30/Dockerfile
+++ b/fedora/30/Dockerfile
@@ -4,6 +4,12 @@ MAINTAINER Alexander Turenko <alexander.turenko@tarantool.org>
 # Fix missing locales
 ENV LC_ALL="C.UTF-8" LANG="C.UTF-8"
 
+# Update repositories and installed packages to avoid of issues got at:
+#   https://github.com/tarantool/tarantool-qa/issues/60
+RUN echo "Remove disabled 'failovermethod' since Fedora 29"
+RUN sed -i '/^failovermethod=/d' /etc/yum.repos.d/*.repo
+RUN dnf update -v -y
+
 # Install base toolset
 RUN dnf -y group install 'Development Tools'
 RUN dnf -y group install 'C Development Tools and Libraries'
@@ -16,3 +22,6 @@ ENV PATH /usr/lib/ccache:/usr/local/bin:/usr/local/sbin:/usr/bin:/usr/sbin:/bin:
 
 # Enable sudo without tty
 RUN sed -i.bak -n -e '/^Defaults.*requiretty/ { s/^/# /;};/^%wheel.*ALL$/ { s/^/# / ;} ;/^#.*wheel.*NOPASSWD/ { s/^#[ ]*//;};p' /etc/sudoers
+
+# Cleanup DNF metadata and decrease image size
+RUN dnf clean all

--- a/fedora/31/Dockerfile
+++ b/fedora/31/Dockerfile
@@ -4,6 +4,10 @@ MAINTAINER Alexey Kopytov <akopytov@gmail.com>
 # Fix missing locales
 ENV LC_ALL="C.UTF-8" LANG="C.UTF-8"
 
+# Update repositories and installed packages to avoid of issues got at:
+#   https://github.com/tarantool/tarantool-qa/issues/60
+RUN dnf update -v -y
+
 # Install base toolset
 RUN dnf -y group install 'Development Tools'
 RUN dnf -y group install 'C Development Tools and Libraries'
@@ -19,3 +23,6 @@ ENV PATH /usr/lib/ccache:/usr/local/bin:/usr/local/sbin:/usr/bin:/usr/sbin:/bin:
 
 # Enable sudo without tty
 RUN sed -i.bak -n -e '/^Defaults.*requiretty/ { s/^/# /;};/^%wheel.*ALL$/ { s/^/# / ;} ;/^#.*wheel.*NOPASSWD/ { s/^#[ ]*//;};p' /etc/sudoers
+
+# Cleanup DNF metadata and decrease image size
+RUN dnf clean all

--- a/fedora/32/Dockerfile
+++ b/fedora/32/Dockerfile
@@ -4,6 +4,10 @@ MAINTAINER Alexander V. Tikhonov <avtikhon@tarantool.org>
 # Fix missing locales
 ENV LC_ALL="C.UTF-8" LANG="C.UTF-8"
 
+# Update repositories and installed packages to avoid of issues got at:
+#   https://github.com/tarantool/tarantool-qa/issues/60
+RUN dnf update -v -y
+
 # Install base toolset
 RUN dnf -y group install 'Development Tools'
 RUN dnf -y group install 'C Development Tools and Libraries'
@@ -19,3 +23,6 @@ ENV PATH /usr/lib/ccache:/usr/local/bin:/usr/local/sbin:/usr/bin:/usr/sbin:/bin:
 
 # Enable sudo without tty
 RUN sed -i.bak -n -e '/^Defaults.*requiretty/ { s/^/# /;};/^%wheel.*ALL$/ { s/^/# / ;} ;/^#.*wheel.*NOPASSWD/ { s/^#[ ]*//;};p' /etc/sudoers
+
+# Cleanup DNF metadata and decrease image size
+RUN dnf clean all

--- a/fedora/33/Dockerfile
+++ b/fedora/33/Dockerfile
@@ -4,6 +4,10 @@ MAINTAINER Alexander V. Tikhonov <avtikhon@tarantool.org>
 # Fix missing locales
 ENV LC_ALL="C.UTF-8" LANG="C.UTF-8"
 
+# Update repositories and installed packages to avoid of issues got at:
+#   https://github.com/tarantool/tarantool-qa/issues/60
+RUN dnf update -v -y
+
 # Install base toolset
 RUN dnf -y group install 'Development Tools'
 RUN dnf -y group install 'C Development Tools and Libraries'
@@ -16,3 +20,6 @@ ENV PATH /usr/lib/ccache:/usr/local/bin:/usr/local/sbin:/usr/bin:/usr/sbin:/bin:
 
 # Enable sudo without tty
 RUN sed -i.bak -n -e '/^Defaults.*requiretty/ { s/^/# /;};/^%wheel.*ALL$/ { s/^/# / ;} ;/^#.*wheel.*NOPASSWD/ { s/^#[ ]*//;};p' /etc/sudoers
+
+# Cleanup DNF metadata and decrease image size
+RUN dnf clean all

--- a/fedora/rawhide/Dockerfile
+++ b/fedora/rawhide/Dockerfile
@@ -4,6 +4,10 @@ MAINTAINER Roman Tsisyk <roman@tarantool.org>
 # Fix missing locales
 ENV LC_ALL="C.UTF-8" LANG="C.UTF-8"
 
+# Update repositories and installed packages to avoid of issues got at:
+#   https://github.com/tarantool/tarantool-qa/issues/60
+RUN dnf update -v -y
+
 # Install base toolset
 RUN dnf -y group install 'Development Tools'
 RUN dnf -y group install 'C Development Tools and Libraries'
@@ -23,3 +27,6 @@ ENV PATH /usr/lib/ccache:/usr/local/bin:/usr/local/sbin:/usr/bin:/usr/sbin:/bin:
 
 # Enable sudo without tty
 RUN sed -i.bak -n -e '/^Defaults.*requiretty/ { s/^/# /;};/^%wheel.*ALL$/ { s/^/# / ;} ;/^#.*wheel.*NOPASSWD/ { s/^#[ ]*//;};p' /etc/sudoers
+
+# Cleanup DNF metadata and decrease image size
+RUN dnf clean all


### PR DESCRIPTION
Found that on old OS with old metadata in cache a lot of connections
hangs on the first packages update. On second packages update command
fails with errors because of hanged connections, like [1]:
```
  237   connect(11, {sa_family=AF_INET6, sin6_port=htons(443), sin6_flowinfo=htonl(0), inet_pton(AF_INET6, "2605:bc80:3010:600:dead:beef:cafe:fed9", &sin6_addr), sin6_scope_id=0}, 28 <unfinished ...>
  236   rt_sigaction(SIGPIPE, NULL,  <unfinished ...>
  237   <... connect resumed>)            = -1 ENETUNREACH (Network is unreachable)
```
To avoid of it on Centos/Fedora images repositories and packages update
call added. Also on Fedora 29/30 images repositories configurations
cleaned from deprecated option 'failovermethod'.

Closes tarantool/tarantool-qa#60

[1]: https://github.com/tarantool/tarantool-qa/issues/60#issuecomment-789596820