### PR TITLE
Remove additional setup of localization and correct PowerTools setup in Centos 8 build

### DIFF
--- a/centos/8/Dockerfile
+++ b/centos/8/Dockerfile
@@ -8,7 +8,8 @@ RUN yum -y install wget yum-utils
 RUN yum -y install epel-release
 # added PowerTools as suggested at:
 #   https://fedoraproject.org/wiki/EPEL
-RUN yum config-manager --set-enabled PowerTools
+RUN sed -i 's/\[PowerTools\]/[powertools]/g' /etc/yum.repos.d/*.repo
+RUN yum config-manager --set-enabled powertools
 
 # Repository for building/testing dependencies that are not present in vanilla
 # CentOS and PowerTools / EPEL repositories, e.g. some Python 2 packages

--- a/centos/8/Dockerfile
+++ b/centos/8/Dockerfile
@@ -12,8 +12,6 @@ RUN yum config-manager --set-enabled PowerTools
 
 # Repository for building/testing dependencies that are not present in vanilla
 # CentOS and PowerTools / EPEL repositories, e.g. some Python 2 packages
-# - fix missing locales
-ENV LC_ALL="C" LANG="en_US.UTF-8"
 # - install the backport repository
 RUN curl -s https://packagecloud.io/install/repositories/packpack/backports/script.rpm.sh | bash
 


### PR DESCRIPTION
Removed extra setup of localization as not needed.
Also found that after DNF update PowerTools repositories became available
only using its new naming in lowercase [1] [2].
    
Co-authored-by: Alexander Turenko <alexander.turenko@tarantool.org>
    
[1]: https://www.reddit.com/r/CentOS/comments/jd7x3d/how_to_enable_powertools_in_centos_stream/
[2]: https://git.centos.org/rpms/centos-repos/blob/c8/f/SOURCES/CentOS-Stream-PowerTools.repo#_11