### PR TITLE
Add Ubuntu Groovy (20.10)

### DIFF
--- a/ubuntu/groovy/Dockerfile
+++ b/ubuntu/groovy/Dockerfile
@@ -1,0 +1,41 @@
+FROM ubuntu:groovy
+MAINTAINER Vitaliia Ioffe <v.ioffe@tarantool.org>
+
+# Fix missing locales
+ENV LC_ALL="C.UTF-8" LANG="C.UTF-8"
+
+# Skip interactive post-install scripts
+ENV DEBIAN_FRONTEND=noninteractive
+
+# Don't install recommends
+RUN echo 'apt::install-recommends "false";' > /etc/apt/apt.conf.d/00recommends
+
+# Enable extra repositories
+RUN apt-get update && apt-get install -y --force-yes \
+    apt-transport-https \
+    curl \
+    wget \
+    gnupg \
+    ca-certificates \
+    software-properties-common
+
+# Install base toolset
+RUN apt-get update && apt-get install -y --force-yes \
+    sudo \
+    git \
+    build-essential \
+    cmake \
+    gdb \
+    ccache \
+    devscripts \
+    debhelper \
+    cdbs \
+    fakeroot \
+    lintian \
+    equivs \
+    rpm \
+    alien \
+    dh-systemd
+
+# Enable sudo without password
+RUN echo '%adm ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers


### PR DESCRIPTION
Created the new Dockerfile to build Ubuntu Groovy based on Ubuntu Focal.

Was used next command:
`v.ioffe@v-ioffe tarantool.bcp % OS=ubuntu DIST=groovy ./packpack/packpack | tee log`

```
Result: 
------------------------------------------------------------------
Debian packages are ready
-------------------------------------------------------------------
   32 /source/build/tarantool-common_2.9.0.10.g7fd53b4c5-1_all.deb
  132 /source/build/tarantool-dev_2.9.0.10.g7fd53b4c5-1_amd64.deb
   16 /source/build/tarantool_2.9.0.10.g7fd53b4c5-1.debian.tar.xz
    4 /source/build/tarantool_2.9.0.10.g7fd53b4c5-1.dsc
 3076 /source/build/tarantool_2.9.0.10.g7fd53b4c5-1_amd64.build
    4 /source/build/tarantool_2.9.0.10.g7fd53b4c5-1_amd64.changes
10244 /source/build/tarantool_2.9.0.10.g7fd53b4c5-1_amd64.deb
    0 /source/build/tarantool_2.9.0.10.g7fd53b4c5.orig.tar.xz
--

make: Leaving directory '/source'
root@docker-desktop:/source# sudo apt install ./build/*.deb
Reading package lists... Done
Building dependency tree       
Reading state information... Done
<....>
root@docker-desktop:/source# /usr/bin/tarantool
Tarantool 2.9.0-10-g7fd53b4c5
type 'help' for interactive help
tarantool> 
tarantool> box.cfg{}
2021-06-01 08:47:00.730 [16868] main/103/interactive C> Tarantool 2.9.0-10-g7fd53b4c5
2021-06-01 08:47:00.730 [16868] main/103/interactive C> log level 5
2021-06-01 08:47:00.730 [16868] main/103/interactive I> wal/engine cleanup is paused
2021-06-01 08:47:00.731 [16868] main/103/interactive I> mapping 268435456 bytes for memtx tuple arena...
2021-06-01 08:47:00.731 [16868] main/103/interactive I> Actual slab_alloc_factor calculated on the basis of desired slab_alloc_factor = 1.044274
2021-06-01 08:47:00.731 [16868] main/103/interactive I> mapping 134217728 bytes for vinyl tuple arena...
2021-06-01 08:47:00.733 [16868] main/103/interactive I> instance uuid b1629bf0-87e4-4354-94b6-a391436345a0
2021-06-01 08:47:00.734 [16868] main/103/interactive I> initializing an empty data directory
2021-06-01 08:47:00.757 [16868] main/103/interactive I> assigned id 1 to replica b1629bf0-87e4-4354-94b6-a391436345a0
2021-06-01 08:47:00.757 [16868] main/103/interactive I> cluster uuid d7a8c1a4-7ca7-4291-bb10-b0178e278221
2021-06-01 08:47:00.769 [16868] snapshot/101/main I> saving snapshot `./00000000000000000000.snap.inprogress'
2021-06-01 08:47:00.772 [16868] snapshot/101/main I> done
2021-06-01 08:47:00.776 [16868] main/103/interactive I> ready to accept requests
2021-06-01 08:47:00.776 [16868] main/104/gc I> wal/engine cleanup is resumed
2021-06-01 08:47:00.777 [16868] main/103/interactive I> set 'log_level' configuration option to 5
2021-06-01 08:47:00.777 [16868] main/105/checkpoint_daemon I> scheduled next checkpoint for Tue Jun  1 10:14:59 2021
2021-06-01 08:47:00.778 [16868] main/103/interactive I> set 'log_format' configuration option to "plain"
---
...

<......>



tarantool> box.space.test:insert{1}
---
- [1]

root@docker-desktop:/source# grep ID /etc/os-release 
ID=ubuntu
ID_LIKE=debian
VERSION_ID="20.10"

```


Part of tarantool/tarantool#5824