### PR TITLE
Add Dockerfile for Debian 11 (bullseye) aarch64 (arm64)

### DIFF
--- a/debian/bullseye/Dockerfile
+++ b/debian/bullseye/Dockerfile
@@ -1,0 +1,40 @@
+FROM arm64v8/debian:bullseye
+MAINTAINER Andrey Kulikov <amdeich@gmail.com>
+
+# Fix missing locales
+ENV LC_ALL="C.UTF-8" LANG="C.UTF-8"
+
+# Skip interactive post-install scripts
+ENV DEBIAN_FRONTEND=noninteractive
+
+# Don't install recommends
+RUN echo 'apt::install-recommends "false";' > /etc/apt/apt.conf.d/00recommends
+
+RUN apt-get update && apt-get upgrade -y 
+
+RUN apt-get update && apt-get install -y \
+    apt-transport-https \
+    curl \
+    wget \
+    gnupg \
+    ca-certificates
+
+# Install base toolset
+RUN apt-get update && apt-get install -y \
+    sudo \
+    git \
+    build-essential \
+    cmake \
+    gdb \
+    ccache \
+    devscripts \
+    debhelper \
+    cdbs \
+    fakeroot \
+    lintian \
+    equivs \
+    rpm \
+    alien
+
+# Enable sudo without password
+RUN echo '%adm ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers


### PR DESCRIPTION
Removed installation of dh-systemd, as this package is not a part of
Debian 11 anymore. It's functionality included into debhelper, which is
installed anyway.

See also: #65

@Totktonada: Dropped --force-yes, because it is deprecated in favor of
--allow-* parameters and because everything works without any of those
parameters. I didn't find a reason why it was added in the first place.
I guess it was attempt to make apt-get fully non-interactive. Let's come
back here if we'll meet any real problem.