### PR TITLE
Add Ubuntu Impish (21.10)

### DIFF
--- a/ubuntu/impish/Dockerfile
+++ b/ubuntu/impish/Dockerfile
@@ -1,0 +1,41 @@
+ARG ARCH=
+FROM ${ARCH}ubuntu:impish
+MAINTAINER Kirill Yukhin <kyukhin@tarantool.org>
+
+# Fix missing locales
+ENV LC_ALL="C.UTF-8" LANG="C.UTF-8"
+
+# Skip interactive post-install scripts
+ENV DEBIAN_FRONTEND=noninteractive
+
+# Don't install recommends
+RUN echo 'apt::install-recommends "false";' > /etc/apt/apt.conf.d/00recommends
+
+# Enable extra repositories
+RUN apt-get update && apt-get install -y --force-yes \
+    apt-transport-https \
+    curl \
+    wget \
+    gnupg \
+    ca-certificates \
+    software-properties-common
+
+# Install base toolset
+RUN apt-get update && apt-get install -y --force-yes \
+    sudo \
+    git \
+    build-essential \
+    cmake \
+    gdb \
+    ccache \
+    devscripts \
+    debhelper \
+    cdbs \
+    fakeroot \
+    lintian \
+    equivs \
+    rpm \
+    alien
+
+# Enable sudo without password
+RUN echo '%adm ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers


### PR DESCRIPTION
Created the new Dockerfile to build Ubuntu Impish based on Ubuntu Groovy.

Part of tarantool/tarantool#6566