### PR TITLE
Resurrect Ubuntu Groovy

### DIFF
--- a/ubuntu/groovy/Dockerfile
+++ b/ubuntu/groovy/Dockerfile
@@ -11,6 +11,11 @@ ENV DEBIAN_FRONTEND=noninteractive
 # Don't install recommends
 RUN echo 'apt::install-recommends "false";' > /etc/apt/apt.conf.d/00recommends
 
+# The repositories are moved to the old-releases archive.
+#
+# https://gist.github.com/dergachev/f5da514802fcbbb441a1
+RUN sed -i -r 's/(archive|security).ubuntu.com/old-releases.ubuntu.com/g' /etc/apt/sources.list
+
 # Enable extra repositories
 RUN apt-get update && apt-get install -y --force-yes \
     apt-transport-https \


### PR DESCRIPTION
The repositories are moved to the old-releases archive, so we should
reflect it in the URLs in sources.list.