### PR TITLE
Add fedora 35

### DIFF
--- a/fedora/35/Dockerfile
+++ b/fedora/35/Dockerfile
@@ -1,0 +1,26 @@
+ARG ARCH=
+FROM ${ARCH}fedora:35
+MAINTAINER Artem Morozov <artembo@me.com>
+
+# Fix missing locales
+ENV LC_ALL="C.UTF-8" LANG="C.UTF-8"
+
+# Update repositories and installed packages to avoid of issues got at:
+#   https://github.com/tarantool/tarantool-qa/issues/60
+RUN dnf update -v -y
+
+# Install base toolset
+RUN dnf -y group install 'Development Tools'
+RUN dnf -y group install 'C Development Tools and Libraries'
+RUN dnf -y group install 'RPM Development Tools'
+RUN dnf -y install fedora-packager
+RUN dnf -y install sudo git ccache cmake
+
+# Enable cache system-wide
+ENV PATH /usr/lib/ccache:/usr/local/bin:/usr/local/sbin:/usr/bin:/usr/sbin:/bin:/sbin
+
+# Enable sudo without tty
+RUN sed -i.bak -n -e '/^Defaults.*requiretty/ { s/^/# /;};/^%wheel.*ALL$/ { s/^/# / ;} ;/^#.*wheel.*NOPASSWD/ { s/^#[ ]*//;};p' /etc/sudoers
+
+# Cleanup DNF metadata and decrease image size
+RUN dnf clean all


### PR DESCRIPTION
Created the new Dockerfile to build Fedora 35 based on Fedora 34

part of tarantool/tarantool#6692