### PR TITLE
Use new backports repo for CentOS 6/7/8

### DIFF
--- a/centos/6/Dockerfile
+++ b/centos/6/Dockerfile
@@ -33,8 +33,14 @@ RUN yum -y install \
     curl \
     pygpgme \
     yum-utils
-RUN curl -s https://packagecloud.io/install/repositories/packpack/backports/script.rpm.sh | bash
-RUN yum makecache && yum clean all
+RUN curl https://packpack.hb.bizmrg.com/backports/el/6/packpack_backports.repo \
+    --fail \
+    --silent \
+    --show-error \
+    --retry 5 \
+    --retry-delay 5 \
+    --output /etc/yum.repos.d/packpack_backports.repo
+RUN yum -y makecache && yum clean all
 
 # Install base toolset
 RUN yum -y groupinstall 'Development Tools'

--- a/centos/7/Dockerfile
+++ b/centos/7/Dockerfile
@@ -18,7 +18,13 @@ RUN yum -y install \
     pygpgme \
     yum-utils
 RUN yum -y install epel-release centos-release-scl centos-release-scl-rh
-RUN curl -s https://packagecloud.io/install/repositories/packpack/backports/script.rpm.sh | bash
+RUN curl https://packpack.hb.bizmrg.com/backports/el/7/packpack_backports.repo \
+    --fail \
+    --silent \
+    --show-error \
+    --retry 5 \
+    --retry-delay 5 \
+    --output /etc/yum.repos.d/packpack_backports.repo
 
 # Install base toolset
 RUN yum -y groupinstall 'Development Tools'

--- a/centos/8/Dockerfile
+++ b/centos/8/Dockerfile
@@ -28,7 +28,13 @@ RUN yum config-manager --set-enabled powertools
 # Repository for building/testing dependencies that are not present in vanilla
 # CentOS and PowerTools / EPEL repositories, e.g. some Python 2 packages
 # - install the backport repository
-RUN curl -s https://packagecloud.io/install/repositories/packpack/backports/script.rpm.sh | bash
+RUN curl https://packpack.hb.bizmrg.com/backports/el/8/packpack_backports.repo \
+    --fail \
+    --silent \
+    --show-error \
+    --retry 5 \
+    --retry-delay 5 \
+    --output /etc/yum.repos.d/packpack_backports.repo
 
 # Install base toolset
 RUN yum -y groupinstall 'Development Tools'


### PR DESCRIPTION
The packagecloud.io service is a chargeable one and it was decided to
move into our own packages infrastructure to optimize expenses.