### PR TITLE
Use new backports repo for Fedora 31/32

### DIFF
--- a/fedora/31/Dockerfile
+++ b/fedora/31/Dockerfile
@@ -16,7 +16,13 @@ RUN dnf -y install fedora-packager
 RUN dnf -y install sudo git ccache cmake
 
 # Setup backport repository for python2 packages
-RUN curl -s https://packagecloud.io/install/repositories/packpack/backports/script.rpm.sh | bash
+RUN curl https://packpack.hb.bizmrg.com/backports/fedora/31/packpack_backports.repo \
+    --fail \
+    --silent \
+    --show-error \
+    --retry 5 \
+    --retry-delay 5 \
+    --output /etc/yum.repos.d/packpack_backports.repo
 
 # Enable cache system-wide
 ENV PATH /usr/lib/ccache:/usr/local/bin:/usr/local/sbin:/usr/bin:/usr/sbin:/bin:/sbin

--- a/fedora/32/Dockerfile
+++ b/fedora/32/Dockerfile
@@ -16,7 +16,13 @@ RUN dnf -y install fedora-packager
 RUN dnf -y install sudo git ccache cmake
 
 # Setup backport repository for python2 packages
-RUN curl -s https://packagecloud.io/install/repositories/packpack/backports/script.rpm.sh | bash
+RUN curl https://packpack.hb.bizmrg.com/backports/fedora/32/packpack_backports.repo \
+    --fail \
+    --silent \
+    --show-error \
+    --retry 5 \
+    --retry-delay 5 \
+    --output /etc/yum.repos.d/packpack_backports.repo
 
 # Enable cache system-wide
 ENV PATH /usr/lib/ccache:/usr/local/bin:/usr/local/sbin:/usr/bin:/usr/sbin:/bin:/sbin


### PR DESCRIPTION
The packagecloud.io service is a chargeable one and it was decided to
move into our own packages infrastructure to optimize expenses.