### PR TITLE
Fix reaching EOL on Fedora 34 and 35 in repos

### DIFF
--- a/fedora/34/Dockerfile
+++ b/fedora/34/Dockerfile
@@ -5,6 +5,14 @@ MAINTAINER Vitaliia Ioffe <v.ioffe@tarantool.org>
 # Fix missing locales
 ENV LC_ALL="C.UTF-8" LANG="C.UTF-8"
 
+# The support for Fedora Linux ended on June 7, 2022. 
+# The package repository has been moved to 
+# http://archives.fedoraproject.org. 
+
+RUN sed -i 's/metalink=/#metalink=/g' /etc/yum.repos.d/*
+RUN sed -i 's/#baseurl=/baseurl=/g' /etc/yum.repos.d/*
+RUN sed -i 's/download.example\/pub/archives.fedoraproject.org\/pub\/archive/g' /etc/yum.repos.d/*
+
 # Update repositories and installed packages to avoid of issues got at:
 #   https://github.com/tarantool/tarantool-qa/issues/60
 RUN dnf update -v -y

--- a/fedora/35/Dockerfile
+++ b/fedora/35/Dockerfile
@@ -5,6 +5,13 @@ MAINTAINER Vitaliia Ioffe <v.ioffe@tarantool.org>
 # Fix missing locales
 ENV LC_ALL="C.UTF-8" LANG="C.UTF-8"
 
+# The support for Fedora Linux ended on December 13, 2022.
+# The package repository has been moved to 
+# http://archives.fedoraproject.org.
+RUN sed -i 's/metalink=/#metalink=/g' /etc/yum.repos.d/*
+RUN sed -i 's/#baseurl=/baseurl=/g' /etc/yum.repos.d/*
+RUN sed -i 's/download.example\/pub/archives.fedoraproject.org\/pub\/archive/g' /etc/yum.repos.d/*
+
 # Update repositories and installed packages to avoid of issues got at:
 #   https://github.com/tarantool/tarantool-qa/issues/60
 RUN dnf update -v -y


### PR DESCRIPTION
The support for Fedora 34 Linux ended on June 6, 2022 and the support for Fedora 35 Linux ended on December 13, 2022. The package repository has been moved to http://archives.fedoraproject.org. Fix url of repos in /etc/yum.repos.d/*.