### PR TITLE
Fix Debian Stretch apt repos, move to archive.debian.org

### DIFF
--- a/debian/stretch/Dockerfile
+++ b/debian/stretch/Dockerfile
@@ -10,6 +10,10 @@ ENV DEBIAN_FRONTEND=noninteractive
 # Don't install recommends
 RUN echo 'apt::install-recommends "false";' > /etc/apt/apt.conf.d/00recommends
 
+# Use the archive repository (see https://wiki.debian.org/LTS/Stretch)
+ADD sources.list /etc/apt/
+RUN echo "Acquire::Check-Valid-Until false;" > /etc/apt/apt.conf.d/00nocheckvalid
+
 # Enable extra repositories
 RUN apt-get update && apt-get install -y --force-yes \
     apt-transport-https \

--- a/debian/stretch/sources.list
+++ b/debian/stretch/sources.list
@@ -1,0 +1,2 @@
+deb http://archive.debian.org/debian stretch main
+deb http://archive.debian.org/debian-security stretch/updates main


### PR DESCRIPTION
Debian Stretch repos moved to archive.debian.org. Patch fixes source.list.