### PR TITLE
Add Debian 12 bookworm images for amd64

### DIFF
--- a/debian/bookworm/Dockerfile
+++ b/debian/bookworm/Dockerfile
@@ -1,0 +1,39 @@
+ARG ARCH=
+FROM ${ARCH}debian:bookworm
+MAINTAINER Andrey Kulikov <amdeich@gmail.com>
+
+# Fix missing locales
+ENV LC_ALL="C.UTF-8" LANG="C.UTF-8"
+
+# Skip interactive post-install scripts
+ENV DEBIAN_FRONTEND=noninteractive
+
+# Don't install recommends
+RUN echo 'apt::install-recommends "false";' > /etc/apt/apt.conf.d/00recommends
+
+RUN apt-get update && apt-get install -y \
+    apt-transport-https \
+    curl \
+    wget \
+    gnupg \
+    ca-certificates
+
+# Install base toolset
+RUN apt-get update && apt-get install -y \
+    sudo \
+    git \
+    build-essential \
+    cmake \
+    gdb \
+    ccache \
+    devscripts \
+    debhelper \
+    cdbs \
+    fakeroot \
+    lintian \
+    equivs \
+    rpm \
+    alien
+
+# Enable sudo without password
+RUN echo '%adm ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers


### PR DESCRIPTION
Debian 12, code named Bookworm, will be released on June 10th 2023.
It's about time to prepare for their arrival.