### PR TITLE
Fix broken repos for Fedora 36

### DIFF
--- a/fedora/36/Dockerfile
+++ b/fedora/36/Dockerfile
@@ -5,6 +5,9 @@ MAINTAINER Yaroslav Lobankov <y.lobankov@tarantool.org>
 # Fix missing locales
 ENV LC_ALL="C.UTF-8" LANG="C.UTF-8"
 
+# Replace repositories because fedora 36 reached EOL at 16 May 2023.
+COPY fedora.repo /etc/yum.repos.d/
+
 # Update repositories and installed packages to avoid issues from:
 #   https://github.com/tarantool/tarantool-qa/issues/60
 RUN dnf update -v -y && \

--- a/fedora/36/fedora.repo
+++ b/fedora/36/fedora.repo
@@ -1,0 +1,36 @@
+[fedora]
+name=Fedora $releasever - $basearch
+baseurl=https://mirrors.kernel.org/fedora/releases/$releasever/Everything/$basearch/os/
+##metalink=https://mirrors.fedoraproject.org/metalink?repo=fedora-$releasever&arch=$basearch
+enabled=1
+countme=1
+metadata_expire=7d
+repo_gpgcheck=0
+type=rpm
+gpgcheck=1
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch
+skip_if_unavailable=False
+
+[fedora-debuginfo]
+name=Fedora $releasever - $basearch - Debug
+baseurl=https://mirrors.kernel.org/fedora/releases/$releasever/Everything/$basearch/debug/tree/
+#metalink=https://mirrors.fedoraproject.org/metalink?repo=fedora-debug-$releasever&arch=$basearch
+enabled=0
+metadata_expire=7d
+repo_gpgcheck=0
+type=rpm
+gpgcheck=1
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch
+skip_if_unavailable=False
+
+[fedora-source]
+name=Fedora $releasever - Source
+baseurl=https://mirrors.kernel.org/fedora/releases/$releasever/Everything/source/tree/
+#metalink=https://mirrors.fedoraproject.org/metalink?repo=fedora-source-$releasever&arch=$basearch
+enabled=0
+metadata_expire=7d
+repo_gpgcheck=0
+type=rpm
+gpgcheck=1
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch
+skip_if_unavailable=False


### PR DESCRIPTION
Fedora 36 reach EOL on 2023-05-16 and the repos are moved to archive. I replaced the repos with the archive repos on
https://mirrors.kernel.org/.