### PR TITLE
Update LD_LIBRARY_PATH for CentOS 7

### DIFF
--- a/centos/7/Dockerfile
+++ b/centos/7/Dockerfile
@@ -44,7 +44,7 @@ RUN sed -i.bak -n -e '/^Defaults.*requiretty/ { s/^/# /;};/^%wheel.*ALL$/ { s/^/
 # Enable devtoolset and ccache system-wide
 # See /opt/rh/${DEVTOOLSET}/enable
 ENV PATH=/usr/lib64/ccache:/opt/rh/${DEVTOOLSET}/root/usr/bin:/opt/rh/${GIT}/root/usr/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
-ENV LD_LIBRARY_PATH=/opt/rh/${DEVTOOLSET}/root/usr/lib64:/opt/rh/${DEVTOOLSET}/root/usr/lib
+ENV LD_LIBRARY_PATH=/opt/rh/${DEVTOOLSET}/root/usr/lib64:/opt/rh/${DEVTOOLSET}/root/usr/lib:/opt/rh/httpd24/root/usr/lib64:/opt/rh/httpd24/root/usr/lib
 ENV PERL5LIB=/opt/rh/${DEVTOOLSET}/root/usr/lib64/perl5/vendor_perl:/opt/rh/${DEVTOOLSET}/root/usr/lib/perl5:/opt/rh/${DEVTOOLSET}/root/usr/share/perl5/vendor_perl
 ENV PYTHONPATH=/opt/rh/${DEVTOOLSET}/root/usr/lib64/python2.7/site-packages:/opt/rh/${DEVTOOLSET}/root/usr/lib/python2.7/site-packages
 ENV XDG_CONFIG_DIRS=/opt/rh/${DEVTOOLSET}/root/etc/xdg:/etc/xdg


### PR DESCRIPTION
The commit 386e95b ("Update git version for CentOS 7 from 1.8 to 2.27") has updated git version in CentOS 7 image, but it hasn't changed the LD_LIBRARY_PATH env variable which was causing the following error:

    /opt/rh/rh-git227/root/usr/libexec/git-core/git-remote-https:
    error while loading shared libraries: libcurl-httpd24.so.4:
    cannot open shared object file: No such file or directory

Now it is fixed.