### PR TITLE
Add Fedora 37

### DIFF
--- a/fedora/37/Dockerfile
+++ b/fedora/37/Dockerfile
@@ -1,0 +1,29 @@
+ARG ARCH=
+FROM ${ARCH}fedora:37
+MAINTAINER Sergey Vorontsov <piligrim@rootnix.net>
+
+# Fix missing locales
+ENV LC_ALL="C.UTF-8" LANG="C.UTF-8"
+
+# Update repositories and installed packages to avoid issues from:
+#   https://github.com/tarantool/tarantool-qa/issues/60
+RUN dnf update -v -y && \
+# Install base toolset
+	dnf -y group install \
+		'Development Tools' \
+		'C Development Tools and Libraries' \
+		'RPM Development Tools' && \
+	dnf -y install \
+		fedora-packager \
+		sudo \
+		git \
+		ccache \
+		cmake && \
+# Cleanup DNF metadata and decrease image size
+	dnf clean all
+
+# Enable cache system-wide
+ENV PATH /usr/lib/ccache:/usr/local/bin:/usr/local/sbin:/usr/bin:/usr/sbin:/bin:/sbin
+
+# Enable sudo without tty
+RUN sed -i.bak -n -e '/^Defaults.*requiretty/ { s/^/# /;};/^%wheel.*ALL$/ { s/^/# / ;} ;/^#.*wheel.*NOPASSWD/ { s/^#[ ]*//;};p' /etc/sudoers


### PR DESCRIPTION
Created the new Dockerfile based on Fedora 36 to build Fedora 37 image.

Part of tarantool/tarantool#9204