### PR TITLE
Add multi-architecture support for AlmaLinux 9

### DIFF
--- a/almalinux/9/Dockerfile
+++ b/almalinux/9/Dockerfile
@@ -1,4 +1,5 @@
-FROM almalinux:9
+ARG ARCH=
+FROM ${ARCH}almalinux:9
 MAINTAINER Oleg Chaplashkin <ochaplashkin@tarantool.org>
 
 RUN dnf -y install \


### PR DESCRIPTION
We have added the ability to choose the base image architecture by using arguments, making the final image more flexible.