### PR TITLE
Update RedOS 7.3

### DIFF
--- a/redos/7.3/Dockerfile
+++ b/redos/7.3/Dockerfile
@@ -1,8 +1,13 @@
-FROM registry.red-soft.ru/ubi7/ubi-minimal:7.3.3-231009
+FROM registry.red-soft.ru/ubi7/ubi:7.3.4-240219
+
 MAINTAINER Sergei Vorontsov "piligrim@rootnix.net"
 
-ENV BACKPORTS_REPO_FILE=https://packpack.hb.bizmrg.com/backports/redos/7.3/packpack_backports.repo
+ENV BACKPORTS_REPO_FILE=https://packpack.hb.vkcs.cloud/backports/redos/7.3/packpack_backports.repo
 
+# Fix missing locales.
+ENV LC_ALL="en_US.UTF-8" LANG="en_US.UTF-8"
+
+# Install backports repo.
 RUN curl $BACKPORTS_REPO_FILE \
     --fail \
     --silent \
@@ -21,12 +26,8 @@ RUN dnf -y update && \
         git \
         sudo \
         dnf-utils && \
-    dnf -y groupinstall 'Development Tools'
+    dnf -y group install 'Development Tools' && \
+    dnf clean all && rm -rf /var/cache/dnf
 
 # Enable sudo without tty.
 RUN sed -i -n -e '/^Defaults.*requiretty/ { s/^/# /;};/^%wheel.*ALL$/ { s/^/# / ;} ;/^#.*wheel.*NOPASSWD/ { s/^#[ ]*//;};p' /etc/sudoers
-
-# Cleanup DNF metadata and decrease image size
-RUN dnf clean all
-
-CMD ["/bin/bash"]


### PR DESCRIPTION
- Use the `ubi` image insted of `ubi-minimal` due to lacking the `dnf` package manager in the `ubi-minimal` image
- Bump OS version to 7.3.4
- Update backports repo URL
- Fix missing locales
- Move cache cleaning to the proper place
- Delete unneeded `CMD` instruction