### PR TITLE
Fix Debian Buster apt repos

### DIFF
--- a/debian/buster/Dockerfile
+++ b/debian/buster/Dockerfile
@@ -11,6 +11,10 @@ ENV DEBIAN_FRONTEND=noninteractive
 # Don't install recommends
 RUN echo 'apt::install-recommends "false";' > /etc/apt/apt.conf.d/00recommends
 
+# Use the archive repository (see https://wiki.debian.org/LTS/Buster)
+ADD sources.list /etc/apt/
+RUN echo "Acquire::Check-Valid-Until false;" > /etc/apt/apt.conf.d/00nocheckvalid
+
 RUN apt-get update && apt-get install -y --force-yes \
     apt-transport-https \
     curl \

--- a/debian/buster/sources.list
+++ b/debian/buster/sources.list
@@ -1,0 +1,2 @@
+deb http://archive.debian.org/debian buster main
+deb http://archive.debian.org/debian-security buster/updates main


### PR DESCRIPTION
These repos are moved to archive.debian.org. See also [1].

[1]: https://wiki.debian.org/LTS/Buster

--- 

Found by [this workflow run in the tarantool-c](https://github.com/tarantool/tarantool-c/actions/runs/21277230575/job/61239178715?pr=179#step:5:409).